### PR TITLE
Install OpenJDK separately

### DIFF
--- a/org.godotengine.Godot3Sharp.yaml
+++ b/org.godotengine.Godot3Sharp.yaml
@@ -1,9 +1,14 @@
 app-id: org.godotengine.Godot3Sharp
-runtime: org.freedesktop.Platform
+runtime: org.freedesktop.Sdk
 runtime-version: '23.08'
 sdk: org.freedesktop.Sdk
+add-extensions:
+  org.freedesktop.Sdk.Extension.openjdk17:
+    directory: jdk
+    version: '23.08'
+    no-autodownload: false
+    autodelete: false
 sdk-extensions:
-  - org.freedesktop.Sdk.Extension.openjdk11
   - org.freedesktop.Sdk.Extension.mono6
   - org.freedesktop.Sdk.Extension.dotnet8
 command: godot
@@ -70,10 +75,10 @@ modules:
 
   - xvfb-module/xvfb.json
 
-  - name: openjdk
+  - name: jdk
     buildsystem: simple
     build-commands:
-      - /usr/lib/sdk/openjdk11/install.sh
+      - mkdir -p /app/jdk
 
   - name: mono
     buildsystem: simple
@@ -107,13 +112,13 @@ modules:
     sources:
       - type: archive
         sha256: 3cb48126b76858f40cf54bd345bb84dc1f49d9e6f8a4a7425ad86e805d39701d
-        url: https://downloads.tuxfamily.org/godotengine/3.5.3/godot-3.5.3-stable.tar.xz
+        url: https://github.com/godotengine/godot-builds/releases/download/3.5.3-stable/godot-3.5.3-stable.tar.xz
 
       - type: script
         dest-filename: godot.sh
         commands:
           - export APPDATA="$XDG_DATA_HOME"
-          - export PATH="/app/jre/bin:$PATH"
+          - if [ -f /app/jdk/enable.sh ]; then source /app/jdk/enable.sh; fi
           - export DOTNET_ROOT="/app/lib/dotnet"
           - export DOTNET_CLI_TELEMETRY_OPTOUT=true
           - export DOTNET_NOLOGO=true

--- a/update-appdata.patch
+++ b/update-appdata.patch
@@ -1,7 +1,7 @@
 diff --git a/misc/dist/linux/org.godotengine.Godot.appdata.xml b/misc/dist/linux/org.godotengine.Godot.appdata.xml
 --- a/misc/dist/linux/org.godotengine.Godot.appdata.xml	2023-03-06 14:13:41.000000000 +0000
 +++ b/misc/dist/linux/org.godotengine.Godot.appdata.xml	2023-03-16 22:20:25.946962567 +0000
-@@ -1,36 +1,75 @@
+@@ -1,36 +1,76 @@
  <?xml version="1.0" encoding="UTF-8"?>
 -<!-- Copyright 2017-2022 Rémi Verschelde <remi@godotengine.org> -->
  <component type="desktop">
@@ -15,6 +15,7 @@ diff --git a/misc/dist/linux/org.godotengine.Godot.appdata.xml b/misc/dist/linux
 +  <name>Godot 3 (C#/.NET)</name>
 +  <summary>Godot game engine editor</summary>
 +  <developer_name>The Godot Engine Community</developer_name>
++  <launchable type="desktop-id">org.godotengine.Godot3Sharp.desktop</launchable>
    <description>
 -    <p>
 -      Godot is an advanced, feature-packed, multi-platform 2D and 3D game


### PR DESCRIPTION
Using the GitHub download link for the source code tarball, while TuxFamily links are currently unavailable due to server downtime.

Mirrors the changes made in https://github.com/flathub/org.godotengine.Godot/pull/166, https://github.com/flathub/org.godotengine.Godot3/pull/9 and https://github.com/flathub/org.godotengine.GodotSharp/pull/13.