### PR TITLE
Update Godot to 3.6

### DIFF
--- a/org.godotengine.Godot3Sharp.yaml
+++ b/org.godotengine.Godot3Sharp.yaml
@@ -20,6 +20,9 @@ build-options:
         # Only enable link-time optimization when targeting x86_64
         # (causes issues on other architectures)
         SCONS_FLAGS_EXTRA: lto=full
+    aarch64:
+      env:
+        SCONS_FLAGS_EXTRA: arch=arm64
 
   append-path: /usr/lib/sdk/mono6/bin:/usr/lib/sdk/dotnet8/bin
 
@@ -111,8 +114,8 @@ modules:
     buildsystem: simple
     sources:
       - type: archive
-        sha256: 3cb48126b76858f40cf54bd345bb84dc1f49d9e6f8a4a7425ad86e805d39701d
-        url: https://github.com/godotengine/godot-builds/releases/download/3.5.3-stable/godot-3.5.3-stable.tar.xz
+        sha256: 5bed20a7056d4cc3cca34001752109809ad7ae200548e98c7bbc6afbad18eda7
+        url: https://github.com/godotengine/godot/releases/download/3.6-stable/godot-3.6-stable.tar.xz
 
       - type: script
         dest-filename: godot.sh

--- a/update-appdata.patch
+++ b/update-appdata.patch
@@ -1,7 +1,7 @@
 diff --git a/misc/dist/linux/org.godotengine.Godot.appdata.xml b/misc/dist/linux/org.godotengine.Godot.appdata.xml
 --- a/misc/dist/linux/org.godotengine.Godot.appdata.xml	2023-03-06 14:13:41.000000000 +0000
 +++ b/misc/dist/linux/org.godotengine.Godot.appdata.xml	2023-03-16 22:20:25.946962567 +0000
-@@ -1,36 +1,77 @@
+@@ -1,36 +1,78 @@
  <?xml version="1.0" encoding="UTF-8"?>
 -<!-- Copyright 2017-2022 Rémi Verschelde <remi@godotengine.org> -->
  <component type="desktop">
@@ -86,6 +86,7 @@ diff --git a/misc/dist/linux/org.godotengine.Godot.appdata.xml b/misc/dist/linux
 +  </screenshots>
 +  <content_rating type="oars-1.1" />
 +  <releases>
++    <release version="3.6" date="2024-09-09"/>
 +    <release version="3.5.3" date="2023-09-25"/>
 +    <release version="3.5.2" date="2023-03-07"/>
 +    <release version="3.5.1" date="2022-09-28"/>


### PR DESCRIPTION
Include aarch64 build fix from https://github.com/flathub/org.godotengine.Godot3/pulls/12 and https://github.com/flathub/org.godotengine.Godot3/pulls/5.

TODO: Update NuGet sources while the PR is running (and before it gets merged).